### PR TITLE
REST calls are not authorized ahainst http anymore, only https

### DIFF
--- a/tasks/install-dynatrace-pwh-connection.yml
+++ b/tasks/install-dynatrace-pwh-connection.yml
@@ -19,4 +19,4 @@
       url: null
 
 - name: Establish the Dynatrace Server's Performance Warehouse connection
-  shell: "curl --fail --silent --write-out '\n%{http_code}' --request PUT --user admin:admin --header 'Content-Type: application/json' --data '{{ dynatrace_server_set_pwh_connection_message | to_json }}' http://localhost:8020/rest/management/pwhconnection/config | cut -d'\n' -f 2"
+  shell: "curl -k --fail --silent --write-out '\n%{http_code}' --request PUT --user admin:admin --header 'Content-Type: application/json' --data '{{ dynatrace_server_set_pwh_connection_message | to_json }}' https://localhost:8021/rest/management/pwhconnection/config | cut -d'\n' -f 2"


### PR DESCRIPTION
I got this error while trying to set the Performance Data Warehouse through REST:

It is forbidden to send authentication data using HTTP. Use HTTPS to ensure that your authentication data is transferred confidentially! Please go to https://localhost:8021/rest/management/.

This change addresses the issue.
