### PR TITLE
Configurable service startup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ dynatrace_server_linux_installer_file_url: "http://downloads.dynatracesaas.com/6
 
 dynatrace_server_collector_port: 6698
 
+dynatrace_server_services_do_startup: yes
+
 dynatrace_server_do_pwh_connection: no
 dynatrace_server_pwh_connection_hostname: localhost
 dynatrace_server_pwh_connection_port: 5432

--- a/tasks/install-dynatrace-server-linux.yml
+++ b/tasks/install-dynatrace-server-linux.yml
@@ -14,7 +14,7 @@
 - include: linux/install-dynatrace-server.yml
 
 - include: install-dynatrace-pwh-connection.yml
-  when: dynatrace_server_do_pwh_connection
+  when: dynatrace_server_do_pwh_connection and dynatrace_server_services_do_startup
 
 - include: linux/remove-dependencies-apt.yml
   when: ansible_pkg_mgr == "apt"

--- a/tasks/linux/install-dynatrace-server.yml
+++ b/tasks/linux/install-dynatrace-server.yml
@@ -118,6 +118,7 @@
     sleep: 5
     enabled: yes
   become: yes
+  when: dynatrace_server_services_do_startup
 
 - name: "Wait for the Dynatrace Server to become available via port {{ item }}"
   wait_for:
@@ -125,3 +126,4 @@
     state: started
   with_items: ["{{ dynatrace_server_collector_port }}", 2021, 6699, 8021, 9911]
   become: yes
+  when: dynatrace_server_services_do_startup


### PR DESCRIPTION
Made it possible to control if the server services should be started
after the installation.
The PWH will only try to connect to the server if the services have been
started.