### PR TITLE
Update java version from 1.7.0 to 1.8.0 - YUM

### DIFF
--- a/tasks/linux/install-dependencies-yum.yml
+++ b/tasks/linux/install-dependencies-yum.yml
@@ -19,9 +19,9 @@
   ignore_errors: yes
   become: yes
 
-- name: Install package 'java-1.7.0-openjdk'
+- name: Install package 'java-1.8.0-openjdk'
   yum:
-    pkg: java-1.7.0-openjdk
+    pkg: java-1.8.0-openjdk
     state: present
   register: java_install
   when: which_java_cmd.rc != 0

--- a/tasks/linux/remove-dependencies-yum.yml
+++ b/tasks/linux/remove-dependencies-yum.yml
@@ -7,9 +7,9 @@
   when: not curl_install | skipped
   become: yes
 
-- name: Remove package 'java-1.7.0-openjdk'
+- name: Remove package 'java-1.8.0-openjdk'
   yum:
-    pkg: java-1.7.0-openjdk
+    pkg: java-1.8.0-openjdk
     state: absent
   ignore_errors: yes
   when: not java_install | skipped


### PR DESCRIPTION
Latest version of Dynatrace doesn't work with Java 1.7.0. Role was failing on CentOS7.
Changing the version of the java package from 1.7.0 to 1.8.0 fixed the issue.
